### PR TITLE
Fix missing GitHub Sponsor for `funding` field in `package.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- Fixed: missing GitHub Sponsor for `funding` field in `package.json`.
+
 ## 0.4.0
 
 - Removed: Node.js less than 18.12.0 support.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,16 @@
     "": {
       "name": "create-stylelint",
       "version": "0.4.0",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "cosmiconfig": "^9.0.0",
@@ -35,10 +45,6 @@
       },
       "engines": {
         "node": ">=18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/stylelint"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -7,10 +7,16 @@
     "npm init"
   ],
   "repository": "stylelint/create-stylelint",
-  "funding": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/stylelint"
-  },
+  "funding": [
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/stylelint"
+    },
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/stylelint"
+    }
+  ],
   "license": "MIT",
   "author": "stylelint",
   "main": "create-stylelint.mjs",


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref https://github.com/stylelint/stylelint/pull/7707

> Is there anything in the PR that needs further explanation?

This change was generated by the snippet in <https://github.com/stylelint/stylelint/pull/7707#issuecomment-2144308259>.
