### PR TITLE
Bump prettier from 3.1.0 to 3.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "eslint-config-stylelint": "^23.0.0",
         "np": "^10.1.0",
         "npm-run-all": "^4.1.5",
+        "prettier": "^3.6.2",
         "remark-cli": "^12.0.1",
         "typescript": "^5.7.2",
         "vitest": "^2.1.6"
@@ -8889,11 +8890,11 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
-      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -17963,11 +17964,10 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
-      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
-      "dev": true,
-      "peer": true
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true
     },
     "prettier-plugin-packagejson": {
       "version": "2.4.7",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "eslint-config-stylelint": "^23.0.0",
     "np": "^10.1.0",
     "npm-run-all": "^4.1.5",
+    "prettier": "^3.6.2",
     "remark-cli": "^12.0.1",
     "typescript": "^5.7.2",
     "vitest": "^2.1.6"


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This bumps the `prettier` package and explicitly adds it to `package.json` to fix the warning:

```sh-session
$ npm run lint:formatting

> create-stylelint@0.5.0 lint:formatting
> prettier . --check --cache

Checking formatting...
[warn] Ignored unknown option { __esModule: true }.
...
```

Note that the issue was resolved in Prettier 3.4.0, ref <https://prettier.io/blog/2024/11/26/3.4.0>.
