### PR TITLE
Create rollup dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     groups:
       development-dependencies:
         dependency-type: 'development'
+      rollup:
+        patterns: ['@rollup/*']
   - package-ecosystem: github-actions
     directory: '/'
     schedule:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None, as it's an infra update

> Is there anything in the PR that needs further explanation?

Grouping these optional deps as they cause conflicts in `package-lock`.
