### PR TITLE
Enable `skipLibCheck` in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
 		"noUncheckedIndexedAccess": true,
 		"esModuleInterop": true,
 		"resolveJsonModule": true,
-		"skipLibCheck": false
+		"skipLibCheck": true
 	},
 	"include": ["src"],
 	"exclude": ["**/*.test.js"]


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Resolves the type error in:
- #126

> Is there anything in the PR that needs further explanation?

This prevents the type error in `node_modules/`, such as:

```
Error: node_modules/strip-indent/index.d.ts(19,25): error TS2528: A module cannot have multiple default exports.
```

https://github.com/stylelint/create-stylelint/actions/runs/18186330053/job/51771262975?pr=126#step:6:51

Also, `tsc --init` outputs `skipLibCheck: true`. It's recommended.

Ref https://www.typescriptlang.org/tsconfig/#skipLibCheck
