### PR TITLE
Add task progression indication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Changed: migrate to ECMAScript module.
+- Added: task progression indication
 
 ## 0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Changed: migrate to ECMAScript module.
-- Added: task progression indication
+- Added: task progression indication.
 
 ## 0.7.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,10 +19,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@inquirer/confirm": "^6.0.4",
+        "@clack/prompts": "^1.2.0",
         "cosmiconfig": "^9.0.1",
         "execa": "^9.6.1",
-        "ora": "^9.3.0",
         "picocolors": "^1.1.1",
         "semver": "^7.7.4",
         "strip-indent": "^4.1.0",
@@ -75,6 +74,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.1.3",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.2.0.tgz",
+      "integrity": "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.2.0",
+        "fast-string-width": "^1.1.0",
+        "fast-wrap-ansi": "^0.1.3",
+        "sisteransi": "^1.0.5"
       }
     },
     "node_modules/@emnapi/core": {
@@ -331,88 +352,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@inquirer/ansi": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.3.tgz",
-      "integrity": "sha512-g44zhR3NIKVs0zUesa4iMzExmZpLUdTLRMCStqX3GE5NT6VkPcxQGJ+uC8tDgBUC/vB1rUhUd55cOf++4NZcmw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      }
-    },
-    "node_modules/@inquirer/confirm": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.4.tgz",
-      "integrity": "sha512-WdaPe7foUnoGYvXzH4jp4wH/3l+dBhZ3uwhKjXjwdrq5tEIFaANxj6zrGHxLdsIA0yKM0kFPVcEalOZXBB5ISA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/core": "^11.1.1",
-        "@inquirer/type": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/core": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.1.tgz",
-      "integrity": "sha512-hV9o15UxX46OyQAtaoMqAOxGR8RVl1aZtDx1jHbCtSJy1tBdTfKxLPKf7utsE4cRy4tcmCQ4+vdV+ca+oNxqNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^2.0.3",
-        "@inquirer/figures": "^2.0.3",
-        "@inquirer/type": "^4.0.3",
-        "cli-width": "^4.1.0",
-        "mute-stream": "^3.0.0",
-        "signal-exit": "^4.1.0",
-        "wrap-ansi": "^9.0.2"
-      },
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@inquirer/figures": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.3.tgz",
-      "integrity": "sha512-y09iGt3JKoOCBQ3w4YrSJdokcD8ciSlMIWsD+auPu+OZpfxLuyz+gICAQ6GCBOmJJt4KEQGHuZSVff2jiNOy7g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      }
-    },
-    "node_modules/@inquirer/type": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.3.tgz",
-      "integrity": "sha512-cKZN7qcXOpj1h+1eTTcGDVLaBIHNMT1Rz9JqJP5MnEJ0JhgVWllx7H/tahUp5YEK1qaByH2Itb8wLG/iScD5kw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1377,7 +1316,7 @@
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -1618,6 +1557,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2058,42 +1998,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/cli-cursor": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
-      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-spinners": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.3.0.tgz",
-      "integrity": "sha512-/+40ljC3ONVnYIttjMWrlL51nItDAbBrq2upN8BPyvGU/2n5Oxw3tbNwORCaNuNqLJnxGqOfjUuhsv7l5Q4IsQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-width": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/collapse-white-space": {
@@ -3149,6 +3053,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-1.2.1.tgz",
+      "integrity": "sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-1.1.0.tgz",
+      "integrity": "sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^1.2.0"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.1.6.tgz",
+      "integrity": "sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^1.1.0"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -3377,18 +3305,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/get-east-asian-width": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -4139,18 +4055,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-interactive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-map": {
@@ -5733,18 +5637,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/mimic-function": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
-      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -5822,15 +5714,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/mute-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
-      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
-      "license": "ISC",
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -6333,21 +6216,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/onetime": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
-      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-function": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6364,56 +6232,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/ora": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
-      "integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.6.2",
-        "cli-cursor": "^5.0.0",
-        "cli-spinners": "^3.2.0",
-        "is-interactive": "^2.0.0",
-        "is-unicode-supported": "^2.1.0",
-        "log-symbols": "^7.0.1",
-        "stdin-discarder": "^0.3.1",
-        "string-width": "^8.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/ora/node_modules/log-symbols": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
-      "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0",
-        "yoctocolors": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/own-keys": {
@@ -7731,22 +7549,6 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
-    "node_modules/restore-cursor": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
-      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^7.0.0",
-        "signal-exit": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -8148,6 +7950,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -8259,18 +8067,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/stdin-discarder": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.1.tgz",
-      "integrity": "sha512-reExS1kSGoElkextOcPkel4NE99S0BWxjUHQeDFnR8S993JxpPX7KU4MNmO19NXhlJp+8dmdCbKQVNgLJh2teA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -8293,22 +8089,6 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/string-width": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
-      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/string-width-cjs": {
@@ -8447,6 +8227,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -8864,7 +8645,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -9652,23 +9433,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
@@ -9724,41 +9488,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -50,10 +50,9 @@
     ]
   },
   "dependencies": {
-    "@inquirer/confirm": "^6.0.4",
+    "@clack/prompts": "^1.2.0",
     "cosmiconfig": "^9.0.1",
     "execa": "^9.6.1",
-    "ora": "^9.3.0",
     "picocolors": "^1.1.1",
     "semver": "^7.7.4",
     "strip-indent": "^4.1.0",

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,14 +1,12 @@
-/* eslint no-console: 'off' */
 /* eslint n/no-process-exit: 'off' */
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import process from 'node:process';
 
-import confirm from '@inquirer/confirm';
+import { cancel, confirm, intro, isCancel, log, note, outro, spinner } from '@clack/prompts';
 import { cosmiconfig } from 'cosmiconfig';
 import { execa } from 'execa';
-import ora from 'ora';
 import pc from 'picocolors';
 import stripIndent from 'strip-indent';
 // @ts-expect-error - TS2595: 'whichPMRuns' can only be imported by using a default import.
@@ -22,6 +20,99 @@ export default {
 };`;
 
 const ADD_COMMAND = 'add -D stylelint stylelint-config-standard';
+
+export async function main() {
+	const pkgManager = whichPMRuns()?.name ?? 'npm';
+	const cwd = './';
+
+	intro(pc.bgGreen(pc.white(' create-stylelint ')));
+
+	note(
+		stripIndent(`
+			Create a ${pc.cyan(DEFAULT_CONFIG_FILE)} file containing:
+
+			  ${DEFAULT_CONFIG_CONTENT.split('\n').join('\n\t\t\t  ')}
+
+			Add the related dependencies using:
+
+			  ${pkgManager} ${ADD_COMMAND}
+		`).trim(),
+		'This tool will:',
+	);
+
+	const shouldContinue = await confirm({ message: 'Continue?' });
+
+	if (isCancel(shouldContinue) || !shouldContinue) {
+		cancel('Canceled');
+		process.exit(0);
+	}
+
+	const configSpinner = spinner();
+
+	configSpinner.start('Creating config');
+
+	try {
+		const existingConfig = await getExistingConfigInDirectory();
+
+		if (existingConfig !== null) {
+			const basename = path.basename(existingConfig.filepath);
+			const failureMessage =
+				basename === 'package.json'
+					? `A ${pc.cyan('stylelint')} entry in ${pc.cyan('package.json')} already exists.`
+					: `A ${pc.cyan(basename)} file already exists.`;
+
+			throw new Error(`${failureMessage} Remove it and then try again.`);
+		}
+
+		if (!directoryHasPackageJson(cwd)) {
+			throw new Error(
+				`A ${pc.cyan('package.json')} was not found. Run ${pc.cyan(`${pkgManager} init`)} and then try again.`,
+			);
+		}
+
+		fs.writeFileSync(DEFAULT_CONFIG_FILE, `${DEFAULT_CONFIG_CONTENT}\n`);
+		configSpinner.stop('Created config file');
+	} catch (error) {
+		handleError(configSpinner, error);
+	}
+
+	const depsSpinner = spinner();
+
+	depsSpinner.start('Adding dependencies');
+
+	try {
+		await execa(pkgManager, [...ADD_COMMAND.split(' ')], { cwd });
+		depsSpinner.stop('Added dependencies');
+	} catch (error) {
+		handleError(depsSpinner, error);
+	}
+
+	log.success('Stylelint is ready!');
+
+	note(
+		stripIndent(`
+			Lint your CSS files:
+
+			  ${pc.dim(`${getExecuteCommand(pkgManager)} stylelint "**/*.css"`)}
+
+			Customize your config:
+
+			- ${pc.underline(pc.cyan('https://stylelint.io/user-guide/customize'))}
+		`).trim(),
+		'Next steps:',
+	);
+
+	log.message(
+		stripIndent(`
+			${pc.dim('Support Stylelint:')}
+
+			${pc.dim(`- ${pc.underline(pc.cyan('https://github.com/sponsors/stylelint'))}`)}
+			${pc.dim(`- ${pc.underline(pc.cyan('https://opencollective.com/stylelint'))}`)}
+		`).trim(),
+	);
+
+	outro(pc.green('Done!'));
+}
 
 async function getExistingConfigInDirectory() {
 	const explorer = cosmiconfig('stylelint');
@@ -38,6 +129,19 @@ function directoryHasPackageJson(dir) {
 }
 
 /**
+ * @param {ReturnType<typeof spinner>} s
+ * @param {unknown} error
+ * @returns {never}
+ */
+function handleError(s, error) {
+	const message = error instanceof Error ? error.message : String(error);
+
+	s.error(message);
+	cancel('Canceled');
+	process.exit(1);
+}
+
+/**
  * @param {string} pkgManager
  * @return {string} The command
  */
@@ -51,158 +155,6 @@ function getExecuteCommand(pkgManager) {
 		case 'yarn':
 			return `${pkgManager} dlx`;
 		default:
-			throw new Error(`"${pkgManager}" package manager is not supported`);
+			throw new Error(`${pc.cyan(pkgManager)} package manager is not supported`);
 	}
-}
-
-/**
- * @param {string} errorMessage
- */
-function cancelSetup(errorMessage = '') {
-	console.error(
-		stripIndent(`
-			${pc.red(pc.bold('Setup canceled!'))}
-		`),
-	);
-
-	if (errorMessage) {
-		console.error(
-			stripIndent(`${errorMessage}
-			`),
-		);
-	}
-
-	process.exit(1);
-}
-
-/**
- * @param {string} pkgManager
- */
-async function showPrompt(pkgManager) {
-	console.info(
-		stripIndent(`
-			We'll create a ${pc.cyan(DEFAULT_CONFIG_FILE)} file containing:
-		`),
-	);
-
-	console.info(
-		pc.dim(
-			DEFAULT_CONFIG_CONTENT.split('\n')
-				.map((line) => `  ${line}`)
-				.join('\n'),
-		),
-	);
-
-	console.info(
-		stripIndent(`
-			Then add the related dependencies using:
-
-			  ${pc.dim(`${pkgManager} ${ADD_COMMAND}`)}
-		`),
-	);
-
-	let proceed;
-
-	try {
-		proceed = await confirm({
-			message: 'Continue?',
-		});
-	} catch (error) {
-		if (error instanceof Error && error.name === 'ExitPromptError') {
-			// silence
-		} else {
-			throw error;
-		}
-	}
-
-	if (!proceed) {
-		cancelSetup();
-	}
-}
-
-/**
- * @param {string} cwd
- * @param {string} pkgManager
- */
-async function createConfig(cwd, pkgManager) {
-	const spinner = ora('Creating config...').start();
-	const existingConfig = await getExistingConfigInDirectory();
-
-	if (existingConfig !== null) {
-		const basename = path.basename(existingConfig.filepath);
-		const failureMessage =
-			basename === 'package.json'
-				? 'A "stylelint" config in "package.json" already exists.'
-				: `A "${basename}" config already exists.`;
-
-		spinner.fail();
-		cancelSetup(`${failureMessage} Remove it and then try again.`);
-	}
-
-	if (!directoryHasPackageJson(cwd)) {
-		spinner.fail();
-		cancelSetup(`A "package.json" was not found. Run "${pkgManager} init" and then try again.`);
-	}
-
-	try {
-		fs.writeFileSync(DEFAULT_CONFIG_FILE, `${DEFAULT_CONFIG_CONTENT}\n`);
-	} catch (error) {
-		spinner.fail();
-		cancelSetup(error instanceof Error ? error.message : String(error));
-	}
-
-	spinner.succeed('Created config file');
-}
-
-/**
- * @param {string} cwd
- * @param {string} pkgManager
- */
-async function addDependencies(cwd, pkgManager) {
-	const spinner = ora('Adding dependencies...').start();
-
-	try {
-		await execa(pkgManager, [...ADD_COMMAND.split(' ')], {
-			cwd,
-		});
-	} catch (error) {
-		spinner.fail();
-		cancelSetup(error instanceof Error ? error.message : String(error));
-	}
-
-	spinner.succeed('Added dependencies');
-}
-
-/**
- * @param {string} pkgManager
- */
-function showNextSteps(pkgManager) {
-	console.info(
-		stripIndent(`
-			${pc.green(pc.bold('Setup complete!'))}
-
-			Lint your CSS files with:
-
-			  ${pc.dim(`${getExecuteCommand(pkgManager)} stylelint "**/*.css"`)}
-
-			Next steps? Customize your config: ${pc.underline(
-				pc.blue('https://stylelint.io/user-guide/customize'),
-			)}
-
-			If you benefit from Stylelint, please consider sponsoring the project at:
-
-			- ${pc.underline(pc.blue('https://github.com/sponsors/stylelint'))}
-			- ${pc.underline(pc.blue('https://opencollective.com/stylelint'))}
-		`),
-	);
-}
-
-export async function main() {
-	const pkgManager = whichPMRuns()?.name ?? 'npm';
-	const cwd = './';
-
-	await showPrompt(pkgManager);
-	await createConfig(cwd, pkgManager);
-	await addDependencies(cwd, pkgManager);
-	showNextSteps(pkgManager);
 }

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -104,9 +104,7 @@ describe('create-stylelint', () => {
 	it('should not proceed if no package.json exists', (context) => {
 		const projectRoot = getProjectRoot(context);
 
-		expect(setupError(inputs.noPackageJson, projectRoot, [], 'yes\n')).toContain(
-			'was not found',
-		);
+		expect(setupError(inputs.noPackageJson, projectRoot, [], 'yes\n')).toContain('was not found');
 	});
 
 	it('should not proceed if the stylelint field exists in package.json', (context) => {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -105,7 +105,7 @@ describe('create-stylelint', () => {
 		const projectRoot = getProjectRoot(context);
 
 		expect(setupError(inputs.noPackageJson, projectRoot, [], 'yes\n')).toContain(
-			'A package.json was not found',
+			'was not found',
 		);
 	});
 
@@ -113,7 +113,7 @@ describe('create-stylelint', () => {
 		const projectRoot = getProjectRoot(context);
 
 		expect(setupError(inputs.stylelintConfigExistsPackageJson, projectRoot, [], 'yes\n')).toContain(
-			'A stylelint entry in package.json already exists.',
+			'already exists.',
 		);
 	});
 

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -26,7 +26,23 @@ function setup(pathToTest, projectRoot, args = [], input = null) {
 	return execFileSync('node', [path.join(projectRoot, 'create-stylelint.mjs'), ...args], {
 		cwd: path.join(projectRoot, pathToTest),
 		input: input !== null ? input : undefined,
-	}).toString();
+		encoding: 'utf8',
+		stdio: ['pipe', 'pipe', 'pipe'],
+	});
+}
+
+function setupError(pathToTest, projectRoot, args = [], input = null) {
+	try {
+		execFileSync('node', [path.join(projectRoot, 'create-stylelint.mjs'), ...args], {
+			cwd: path.join(projectRoot, pathToTest),
+			input: input !== null ? input : undefined,
+			encoding: 'utf8',
+			stdio: ['pipe', 'pipe', 'pipe'],
+		});
+		throw new Error('Expected process to exit with non-zero code');
+	} catch (error) {
+		return error.stdout + error.stderr;
+	}
 }
 
 function backupFiles(root) {
@@ -70,41 +86,41 @@ describe('create-stylelint', () => {
 	it('should succeed in a valid env with yes prompt', (context) => {
 		const projectRoot = getProjectRoot(context);
 
-		expect(setup(inputs.validEnv, projectRoot, [], 'yes\n')).toContain('Setup complete');
+		expect(setup(inputs.validEnv, projectRoot, [], 'yes\n')).toContain('Done!');
 	}, 15000);
 
-	it('should succeed in a valid env with enter prompt', (context) => {
+	it('should succeed in a valid env with y prompt', (context) => {
 		const projectRoot = getProjectRoot(context);
 
-		expect(setup(inputs.validEnv, projectRoot, [], '\n')).toContain('Setup complete');
+		expect(setup(inputs.validEnv, projectRoot, [], 'y\n')).toContain('Done!');
 	}, 15000);
 
 	it("should cancel setup if user chooses 'no' at confirmation", (context) => {
 		const projectRoot = getProjectRoot(context);
 
-		expect(() => setup(inputs.validEnv, projectRoot, [], 'no\n')).toThrowError('Setup canceled');
+		expect(setup(inputs.validEnv, projectRoot, [], 'no\n')).toContain('Canceled');
 	});
 
 	it('should not proceed if no package.json exists', (context) => {
 		const projectRoot = getProjectRoot(context);
 
-		expect(() => setup(inputs.noPackageJson, projectRoot, [], 'yes\n')).toThrowError(
-			'A "package.json" was not found',
+		expect(setupError(inputs.noPackageJson, projectRoot, [], 'yes\n')).toContain(
+			'A package.json was not found',
 		);
 	});
 
 	it('should not proceed if the stylelint field exists in package.json', (context) => {
 		const projectRoot = getProjectRoot(context);
 
-		expect(() =>
-			setup(inputs.stylelintConfigExistsPackageJson, projectRoot, [], 'yes\n'),
-		).toThrowError('A "stylelint" config in "package.json" already exists.');
+		expect(setupError(inputs.stylelintConfigExistsPackageJson, projectRoot, [], 'yes\n')).toContain(
+			'A stylelint entry in package.json already exists.',
+		);
 	});
 
 	it('should error if npm install fails', (context) => {
 		const projectRoot = getProjectRoot(context);
 
-		expect(() => setup(inputs.failNpmInstall, projectRoot, [], 'yes\n')).toThrowError(
+		expect(setupError(inputs.failNpmInstall, projectRoot, [], 'yes\n')).toContain(
 			'npm error code ETARGET',
 		);
 	}, 15000);
@@ -139,6 +155,6 @@ describe.each([
 	it(`should not proceed, since a stylelint configuration already exists at ${file}`, (context) => {
 		const projectRoot = getProjectRoot(context);
 
-		expect(() => setup(fixture, projectRoot, [], 'yes\n')).toThrowError('config already exists');
+		expect(setupError(fixture, projectRoot, [], 'yes\n')).toContain('already exists.');
 	});
 });


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/create-stylelint/pull/173

@ybiquitous Thank you for looking into that issue.

I couldn't see an obvious solution either, so let's treat this as an opportunity to modernise the libraries we use.

> Is there anything in the PR that needs further explanation?

In https://github.com/stylelint/create-stylelint/pull/105, we followed Astro's lead and rolled our own interface using `@inquirer/confirm` and `ora`.

Astro has since moved on to using [`@clack/prompts`](https://www.npmjs.com/package/@clack/prompts), and it seems other tools are migrating to it as part of the [Ecosystem Performance initiative](https://e18e.dev/).

This PR does the same for our create tool, migrating our custom solution to a unified one.

It comes with some nice improvements, including:
- consistent visual style
- visual task progression  (from "create-stylelint" to "Done!")
- graceful handling of `ctrl+c`

As this tool is often people's first experience of Stylelint, these improvements are welcome.

The flow hasn't changed:
1. explain what the tool will do
2. single "Continue?" confirmation prompt
3. success or error message

I did refine some copy and how it's grouped to take advantage of the Clack primitives:
- adding a "Stylelint is ready!" success message before "Next steps"
- splitting "Next steps" (`note`) and "Support Stylelint" (`message`)

---

Success screenshot:

<img width="538" height="580" alt="Screenshot 2026-04-06 at 19 12 31" src="https://github.com/user-attachments/assets/b4fb5502-5a81-45fa-894a-52ab4152eeff" />

---

Success video:

https://github.com/user-attachments/assets/a6e4159c-393d-4dbc-b8d7-ba5afaca8d9f

---

Canceled screenshot (`ctrl+c`):

<img width="454" height="284" alt="Screenshot 2026-04-06 at 19 11 13" src="https://github.com/user-attachments/assets/a9453f13-e0f7-42ba-b34e-fc0baf5cf99b" />

(The previous interface can be seen in https://github.com/stylelint/create-stylelint/pull/105.)

---

Unfortunately, the diff is fragmented, but the [undiffed code](https://github.com/stylelint/create-stylelint/blob/81d5ff92f53904d6db6bb2f5af8507b5eff41fd6/src/index.mjs) feels cleaner and may be easier to review.
