### PR TITLE
Fix quoted `extends` property key in generated `stylelint.config.mjs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Head
+
+- Fixed: quoted `extends` property key in generated `stylelint.config.mjs`.
+
 ## 1.0.0
 
 - Changed: migrate to ECMAScript module.

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -16,7 +16,7 @@ import { whichPMRuns } from 'which-pm-runs';
 const DEFAULT_CONFIG_FILE = 'stylelint.config.mjs';
 const DEFAULT_CONFIG_CONTENT = `/** @type {import("stylelint").Config} */
 export default {
-  "extends": ["stylelint-config-standard"]
+  extends: ["stylelint-config-standard"]
 };`;
 
 const ADD_COMMAND = 'add -D stylelint stylelint-config-standard';

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -89,6 +89,18 @@ describe('create-stylelint', () => {
 		expect(setup(inputs.validEnv, projectRoot, [], 'yes\n')).toContain('Done!');
 	}, 15000);
 
+	it('should generate a valid config file', (context) => {
+		const projectRoot = getProjectRoot(context);
+
+		setup(inputs.validEnv, projectRoot, [], 'yes\n');
+
+		const configPath = path.join(projectRoot, inputs.validEnv, 'stylelint.config.mjs');
+		const content = fs.readFileSync(configPath, 'utf8');
+
+		expect(content).toContain('extends: ["stylelint-config-standard"]');
+		expect(() => execFileSync('node', ['--check', configPath], { encoding: 'utf8' })).not.toThrow();
+	}, 15000);
+
 	it('should succeed in a valid env with y prompt', (context) => {
 		const projectRoot = getProjectRoot(context);
 


### PR DESCRIPTION

<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None. It's a minor bug fix.

> Is there anything in the PR that needs further explanation?

The Stylelint documentation suggests the unquoted `extends` key.
Ref: https://stylelint.io/user-guide/get-started/#manual-setup

